### PR TITLE
Make TOC more compact and separate sections

### DIFF
--- a/_plugin/xsl/dita2html.xsl
+++ b/_plugin/xsl/dita2html.xsl
@@ -90,6 +90,30 @@
     <xsl:text>&#xA;</xsl:text>
   </xsl:template>
 
+  <xsl:template match="*[contains(@class, ' topic/topic ')]/*[contains(@class, ' topic/title ')]">
+    <xsl:param name="headinglevel" as="xs:integer">
+      <xsl:choose>
+        <xsl:when test="count(ancestor::*[contains(@class, ' topic/topic ')]) > 6">6</xsl:when>
+        <xsl:otherwise><xsl:sequence select="count(ancestor::*[contains(@class, ' topic/topic ')])"/></xsl:otherwise>
+      </xsl:choose>
+    </xsl:param>
+    <xsl:element name="h{$headinglevel}">
+      <xsl:attribute name="class" select="concat('topictitle', $headinglevel)"/>
+      <xsl:call-template name="commonattributes">
+        <xsl:with-param name="default-output-class">topictitle<xsl:value-of select="$headinglevel"/></xsl:with-param>
+      </xsl:call-template>
+      <xsl:attribute name="id"><xsl:apply-templates select="." mode="return-aria-label-id"/></xsl:attribute>
+      <xsl:choose>
+        <xsl:when test="$headinglevel eq = 1 and $FILENAME eq 'oasis-cover.dita'">
+          <xsl:apply-templates select="$input.map/*/*[contains(@class, ' bookmap/booktitle ')]/*[contains(@class, ' bookmap/mainbooktitle ')]/node()"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template match="node()" mode="jekyll-layout" as="xs:string">
     <xsl:value-of select="$layout"/>
   </xsl:template>

--- a/css/_toc.scss
+++ b/css/_toc.scss
@@ -49,10 +49,16 @@ nav[role='toc'] {
     display: block;
     position: relative;
 
+    // separate fronhead, body, and appendices with space
+    &:not(.chapter) + .chapter,
+    &:not(.appendix) + .appendix {
+      @extend .mt-3;
+    }
+
     > a {
       display: block;
       margin: 0;
-      padding: 3px 20px;
+      padding: 0px 20px;
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
@@ -85,6 +91,7 @@ nav[role='toc'] {
     cursor: pointer;
     display: inline-block;
     height: 1em;
+    top: -0.2em;
     left: -0.8em;
     padding-left: 0;
     position: absolute;


### PR DESCRIPTION
* Reduce padding in TOC items to make the TOC more compact.
* Separate frontmatter and appendices with space