### PR TITLE
Bump DITA-OT used for builds from 4.3.3 to 4.4

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DITA_OT_VERSION: '4.3.3'
+      DITA_OT_VERSION: '4.4'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dita-techcomm.yml
+++ b/.github/workflows/dita-techcomm.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DITA_OT_VERSION: '4.3.3'
+      DITA_OT_VERSION: '4.4'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dita.yml
+++ b/.github/workflows/dita.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DITA_OT_VERSION: '4.3.3'
+      DITA_OT_VERSION: '4.4'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dita_v1.3.yml
+++ b/.github/workflows/dita_v1.3.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DITA_OT_VERSION: '4.3.3'
+      DITA_OT_VERSION: '4.4'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/lwdita.yml
+++ b/.github/workflows/lwdita.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DITA_OT_VERSION: '4.3.3'
+      DITA_OT_VERSION: '4.4'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
DITA-OT 4.4 includes some DITA 2.0 related processing that should be in place for this build before the spec source migrates to use 2.0